### PR TITLE
gitogram: Add username/pass auth for http repos

### DIFF
--- a/.github/workflows/gitogram.yml
+++ b/.github/workflows/gitogram.yml
@@ -2,7 +2,7 @@ name: build
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "add-username-pass-auth" ]
   pull_request:
     branches: [ "main" ]
 

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"testing"
 
@@ -83,14 +84,14 @@ func TestAddChat(t *testing.T) {
 			envName:  "TEST_CHAT_URL_EMPTY",
 			giveUrl:  "",
 			wantName: "",
-			wantErr:  ErrPushChatInfo,
+			wantErr:  fmt.Errorf("%s: %w", ErrPushChatInfo.Error(), errors.New("unknown error: Gogs: You do not have sufficient authorization for this action")),
 		},
 		{
 			name:     "Test already clonned chat",
 			envName:  "TEST_CHAT_URL_EMPTY",
 			giveUrl:  "",
 			wantName: "",
-			wantErr:  ErrPushChatInfo,
+			wantErr:  fmt.Errorf("%s: %w", ErrPushChatInfo.Error(), errors.New("unknown error: Gogs: You do not have sufficient authorization for this action")),
 		},
 	}
 
@@ -114,7 +115,7 @@ func TestAddChat(t *testing.T) {
 
 	for _, tt := range subtests {
 		t.Run(tt.name, func(t *testing.T) {
-			ans, err := AddChat(tt.giveUrl)
+			ans, err := AddChat(tt.giveUrl, "", "")
 			assert.Equal(t, tt.wantName, ans.Name)
 			assert.Equal(t, tt.wantErr, err)
 		})


### PR DESCRIPTION
It is required to provide a username and password when cloning repos via HTTP. So added authentication modal to ask the user for credentials. This credential will be stored for each chat and passed to all push and pull commands for corresponding chat.

go-git doesn't support git credential helpers, so I decided to store username/pass pairs in local file in chat directory. Since git-credential-store stores credentials in .git-credentials file in plaintext, I thought I can do same.

[1] https://github.com/go-git/go-git/issues/28
[2] https://git-scm.com/docs/git-credential-store

Issue: #40